### PR TITLE
Add timeout rplidar driver if successful scans are not recieved

### DIFF
--- a/launch/rplidar.launch
+++ b/launch/rplidar.launch
@@ -1,5 +1,5 @@
 <launch>
-  <node name="rplidarNode"          pkg="rplidar_ros"  type="rplidarNode" output="screen">
+  <node name="rplidarNode"          pkg="rplidar_ros"  type="rplidarNode" respawn="true" output="screen">
   <param name="serial_port"         type="string" value="/dev/ttyUSB0"/>  
   <param name="serial_baudrate"     type="int"    value="115200"/>
   <param name="frame_id"            type="string" value="laser"/>

--- a/launch/rplidar.launch
+++ b/launch/rplidar.launch
@@ -5,5 +5,6 @@
   <param name="frame_id"            type="string" value="laser"/>
   <param name="inverted"            type="bool"   value="false"/>
   <param name="angle_compensate"    type="bool"   value="true"/>
+  <param name="rplidar_timeout"     type="int"    value="5"/>
   </node>
 </launch>

--- a/src/node.cpp
+++ b/src/node.cpp
@@ -196,6 +196,8 @@ int main(int argc, char * argv[]) {
     ros::Publisher diag_pub = nh.advertise<diagnostic_msgs::DiagnosticArray>("diagnostics", 10);
 
     ros::NodeHandle nh_private("~");
+    int rplidar_timeout;
+    nh_private.param<int>("rplidar_timeout", rplidar_timeout, 5);
     nh_private.param<std::string>("serial_port", serial_port, "/dev/ttyUSB0"); 
     nh_private.param<int>("serial_baudrate", serial_baudrate, 115200); 
     nh_private.param<std::string>("frame_id", frame_id, "laser_frame");
@@ -239,6 +241,7 @@ int main(int argc, char * argv[]) {
     ros::Time start_scan_time;
     ros::Time end_scan_time;
     double scan_duration;
+    int time_since_last_scan = ros::Time::now().sec;
     while (ros::ok()) {
 
         rplidar_response_measurement_node_t nodes[360*2];
@@ -250,6 +253,7 @@ int main(int argc, char * argv[]) {
         scan_duration = (end_scan_time - start_scan_time).toSec() * 1e-3;
 
         if (op_result == RESULT_OK) {
+            time_since_last_scan = ros::Time::now().sec;
             op_result = drv->ascendScanData(nodes, count);
 
             float angle_min = DEG2RAD(0.0f);
@@ -272,6 +276,7 @@ int main(int argc, char * argv[]) {
                             }
                         }
                     }
+
   
                     publish_scan(&scan_pub, angle_compensate_nodes, angle_compensate_nodes_count,
                              start_scan_time, scan_duration, inverted,  
@@ -295,6 +300,7 @@ int main(int argc, char * argv[]) {
                              angle_min, angle_max, 
                              frame_id, distance_factor);
                }
+               time_since_last_scan = ros::Time::now().sec;
             } else if (op_result == RESULT_OPERATION_FAIL) {
                 publish_diag(serial_port, diagnostic_msgs::DiagnosticStatus::ERROR, 
                         "Can't grab scan data (code RESULT_OPERATION_FAIL)", diag_pub);
@@ -308,6 +314,10 @@ int main(int argc, char * argv[]) {
                              frame_id, distance_factor);
             }
         }
+        if(ros::Time::now().sec - time_since_last_scan > rplidar_timeout){
+            return 124;
+        }
+
 
         ros::spinOnce();
     }

--- a/src/node.cpp
+++ b/src/node.cpp
@@ -253,9 +253,7 @@ int main(int argc, char * argv[]) {
         scan_duration = (end_scan_time - start_scan_time).toSec() * 1e-3;
 
         if (op_result == RESULT_OK) {
-            time_since_last_scan = ros::Time::now().sec;
-            op_result = drv->ascendScanData(nodes, count);
-
+             op_result = drv->ascendScanData(nodes, count);
             float angle_min = DEG2RAD(0.0f);
             float angle_max = DEG2RAD(359.0f);
             if (op_result == RESULT_OK) {


### PR DESCRIPTION
Sometimes the rplidar ros driver hangs without publishing.  Now if no scans are received for 5 seconds rplidar_ros kills itself and respawns
